### PR TITLE
Feature 6814: Additional Features

### DIFF
--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -11,9 +11,20 @@ from conans.errors import ConanException
 class ConanGrapher(object):
 
     def __init__(self, deps_graph):
+        """
+        Object to write the Conan dependency graph into a Graphviz Dot file
+        (https://www.graphviz.org/doc/info/lang.html)
+
+        :param deps_graph: Conan built-in Dependency Graph
+        """
         self._deps_graph = deps_graph
 
     def graph(self):
+        """
+        Creates the Dot file content.
+
+        :return: String with a content of the Dot file for the defined deps_graph.
+        """
         dot_graph = ['strict digraph {']
         dot_graph.append(self._dot_configuration)
         dot_graph.append('\n')
@@ -29,9 +40,21 @@ class ConanGrapher(object):
         return ''.join(dot_graph)
 
     def graph_file(self, output_filename):
+        """
+        Writes the defined deps_graph tree into a Dot file.
+
+        :param output_filename: filename of the output Dot file.
+        """
         save(output_filename, self.graph())
 
     def _add_single_nodes_to_graph(self, dot_graph):
+        """
+        Creates a nodes representation with all the fields to be displayed in the Dot file and
+        fills-in the nodes of the Dot graph (dot_graph) with this information.
+
+        :param dot_graph: String containing the DOT file structure (the Dot configuration)
+        :return: A Map of nodes identified by its display_name with all the useful fields.
+        """
         # Store list of build_requires nodes
         build_time_nodes = self._deps_graph.build_time_nodes()
 
@@ -113,6 +136,13 @@ class ConanGrapher(object):
         return nodes
 
     def _add_adjacency_matrix(self, nodes, dot_graph):
+        """
+        Fills in the adjancency matrix into the dot_graph string in the following form
+            "node_id" -> {"dep_1_id" "dep_2_id" ... "dep_n_id"}
+
+        :param nodes: A Map of nodes identified by its display_name with all the useful fields.
+        :param dot_graph: String containing the DOT file structure (the DOT configuration and nodes)
+        """
         for id in sorted(nodes.keys()):
             depends = nodes[id]['node'].neighbors()
             if depends:

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -7,6 +7,7 @@ from conans.client.installer import build_id
 from conans.util.files import save
 from conans.errors import ConanException
 
+
 class ConanGrapher(object):
 
     def __init__(self, deps_graph):
@@ -72,30 +73,29 @@ class ConanGrapher(object):
                 node_channel = ""
 
             nodes[node_id] = {
-              "node": node,
-              "name": node_name,
-              "version": node_version,
-              "user": node_user,
-              "channel": node_channel,
-              "is_root": node_id == root_id,
-              "build_requires": node in build_time_nodes
+                "node": node,
+                "name": node_name,
+                "version": node_version,
+                "user": node_user,
+                "channel": node_channel,
+                "is_root": node_id == root_id,
+                "build_requires": node in build_time_nodes
             }
-
 
         # Then iterate over the ordered set of nodes & write to dot graph
         for id in sorted(nodes.keys()):
             if nodes[id]['version'] and nodes[id]['user'] and nodes[id]['channel']:
-                dot_node = self._dot_node_template_with_user_channel\
-                                                  .replace("%NODE_NAME%", nodes[id]['name']) \
-                                                  .replace("%NODE_VERSION%", nodes[id]['version']) \
-                                                  .replace("%NODE_USER%", nodes[id]['user']) \
-                                                  .replace("%NODE_CHANNEL%", nodes[id]['channel'])
+                dot_node = self._dot_node_template_with_user_channel \
+                    .replace("%NODE_NAME%", nodes[id]['name']) \
+                    .replace("%NODE_VERSION%", nodes[id]['version']) \
+                    .replace("%NODE_USER%", nodes[id]['user']) \
+                    .replace("%NODE_CHANNEL%", nodes[id]['channel'])
             elif nodes[id]['version']:
                 dot_node = self._dot_node_template.replace("%NODE_NAME%", nodes[id]['name']) \
-                                                  .replace("%NODE_VERSION%", nodes[id]['version'])
+                    .replace("%NODE_VERSION%", nodes[id]['version'])
             else:
                 dot_node = self._dot_node_template_without_version_user_channel \
-                                                  .replace("%NODE_NAME%", nodes[id]['name'])
+                    .replace("%NODE_NAME%", nodes[id]['name'])
             # Color the nodes
             if nodes[id]['is_root']:
                 dot_node = self._dot_node_colors_template_root_node + dot_node
@@ -120,7 +120,8 @@ class ConanGrapher(object):
                 deps_links = ""
                 for dep_node in depends:
                     if dep_node.conanfile.name and dep_node.conanfile.version:
-                        dep_node_id = "{}/{}".format(dep_node.conanfile.name, dep_node.conanfile.version)
+                        dep_node_id = "{}/{}".format(dep_node.conanfile.name,
+                                                     dep_node.conanfile.version)
                     elif dep_node.conanfile.name:
                         dep_node_id = dep_node.conanfile.name
                     else:
@@ -173,6 +174,7 @@ class ConanGrapher(object):
        <tr><td align="center"><font point-size="12">%NODE_VERSION%</font></td></tr>
      </table>>];"""
 
+
 class ConanHTMLGrapher(object):
     def __init__(self, deps_graph, cache_folder):
         self._deps_graph = deps_graph
@@ -220,7 +222,7 @@ class ConanHTMLGrapher(object):
             fulllabel.append("<ul>")
             fulllabel = "".join(fulllabel)
 
-            if node in build_time_nodes:   # TODO: May use build_require_context information
+            if node in build_time_nodes:  # TODO: May use build_require_context information
                 shape = "ellipse"
             else:
                 shape = "box"

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -15,13 +15,20 @@ class ConanGrapher(object):
         graph_lines = ['strict digraph {']
         graph_lines.append(self._dot_configuration)
         graph_lines.append('\n')
-        # First, create the nodes
-        graph_nodes = self._deps_graph.by_levels()
+
+        # Store list of build_requires nodes
         build_time_nodes = self._deps_graph.build_time_nodes()
+
+        # Store the root node
+        root_id = self._deps_graph.root.conanfile.display_name
+
+        # First, create the nodes
         for node in self._deps_graph.nodes:
+            # Node id is name/version, unless there's no name & version
             node_id = node.conanfile.display_name
             node_name = node.conanfile.name if node.conanfile.name else node.conanfile.display_name
             node_version = node.conanfile.version if node.conanfile.version else ""
+
             try:
                 node_user = node.conanfile.user
             except ConanException:
@@ -47,11 +54,16 @@ class ConanGrapher(object):
             else:
                 dot_node = self._dot_node_template_without_name_version_user_channel
 
-            if node in build_time_nodes:   # TODO: May use build_require_context information
-                dot_node = self._dot_node_template_build_requires + dot_node
-            else:
-                dot_node = self._dot_node_template_requires + dot_node
+            # Color the nodes
+            if node_id == root_id:  # root node
+                dot_node = self._dot_node_colors_template_root_node + dot_node
+            elif node in build_time_nodes:  # build_requires
+                # TODO: May use build_require_context information
+                dot_node = self._dot_node_colors_template_build_requires + dot_node
+            else:  # requires
+                dot_node = self._dot_node_colors_template_requires + dot_node
 
+            # Add single node to graph
             graph_lines.append('    "%s" %s\n' % (node_id, dot_node))
 
         # Then, the adjacency matrix
@@ -88,8 +100,9 @@ class ConanGrapher(object):
     edge [
       style = solid,
     ];"""
-    _dot_node_template_build_requires = """[ fillcolor=lightyellow, color=gold """
-    _dot_node_template_requires = """[ fillcolor=azure, color=dodgerblue """
+    _dot_node_colors_template_root_node = """[ fillcolor=mintcream, color=limegreen """
+    _dot_node_colors_template_build_requires = """[ fillcolor=lightyellow, color=gold """
+    _dot_node_colors_template_requires = """[ fillcolor=azure, color=dodgerblue """
     _dot_node_template_without_name_version_user_channel = """ """
     _dot_node_template_without_version_user_channel = """ label=<
      <table border="0" cellborder="0" cellspacing="0">

--- a/conans/client/graph/grapher.py
+++ b/conans/client/graph/grapher.py
@@ -52,15 +52,14 @@ class ConanGrapher(object):
             if node.conanfile.name and node.conanfile.version:
                 node_name = node.conanfile.name
                 node_version = node.conanfile.version
-                node_id = "{}/{}".format(node.conanfile.name, node.conanfile.version)
             elif node.conanfile.name:
                 node_name = node.conanfile.name
                 node_version = ""
-                node_id = node_name
             else:
                 node_name = node.conanfile.display_name
                 node_version = ""
-                node_id = node_name
+
+            node_id = node.conanfile.display_name
 
             try:
                 node_user = node.conanfile.user
@@ -119,14 +118,7 @@ class ConanGrapher(object):
             if depends:
                 deps_links = ""
                 for dep_node in depends:
-                    if dep_node.conanfile.name and dep_node.conanfile.version:
-                        dep_node_id = "{}/{}".format(dep_node.conanfile.name,
-                                                     dep_node.conanfile.version)
-                    elif dep_node.conanfile.name:
-                        dep_node_id = dep_node.conanfile.name
-                    else:
-                        dep_node_id = dep_node.conanfile.display_name
-
+                    dep_node_id = dep_node.conanfile.display_name
                     deps_links += ' "%s"' % dep_node_id
 
                 # Add nodes to matrix
@@ -148,19 +140,17 @@ class ConanGrapher(object):
       style = "filled",
       fontname = "Helvetica",
       fontsize = "18",
-      shape=rect,
-      fillcolor=azure2,
-      color=dodgerblue4
+      shape=rect
     ];
     edge [
-      style = solid,
+      style = solid
     ];"""
     _dot_node_colors_template_root_node = """[ fillcolor=mintcream, color=limegreen """
     _dot_node_colors_template_build_requires = """[ fillcolor=lightyellow, color=gold """
     _dot_node_colors_template_requires = """[ fillcolor=azure, color=dodgerblue """
     _dot_node_template_without_version_user_channel = """ label=<
      <table border="0" cellborder="0" cellspacing="0">
-       <tr><td align="center"><b>%NODE_NAME%</b></td></tr></i></td></tr>
+       <tr><td align="center"><b>%NODE_NAME%</b></td></tr>
      </table>>];"""
     _dot_node_template_with_user_channel = """ label=<
      <table border="0" cellborder="0" cellspacing="0">

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -136,10 +136,9 @@ class InfoTest(unittest.TestCase):
             self.assertEqual(ref.channel, "stable")
 
         def check_digraph_line(line):
-
             self.assertTrue(dot_regex.match(line) or
                             dot_format_section_regex.match(line) or
-                            dot_format_value_regex.match(line) or
+                            dot_format_section_value_regex.match(line) or
                             dot_node_format_regex.match(line) or
                             dot_node_format_body_regex.match(line)
                             )
@@ -152,7 +151,7 @@ class InfoTest(unittest.TestCase):
             parent_reference = node_matches[0]
             deps_ref = [ConanFileReference.loads(references) for references in node_matches[1:]]
 
-            if parent_reference == "conanfile.py (Hello0/0.1)":
+            if parent_reference == "Hello0/0.1":
                 parent_ref = ConanFileReference("Hello0", None, None, None, validate=False)
             else:
                 parent_ref = ConanFileReference.loads(parent_reference)
@@ -172,11 +171,13 @@ class InfoTest(unittest.TestCase):
         create_export(test_deps, "Hello0")
 
         node_regex = re.compile(r'"([^"]+)"')
-        dot_regex = re.compile(r'^\s+"[^"]+" -> {"[^"]+"( "[^"]+")*}$')
-        dot_format_section_regex = re.compile(r'^\s+(graph|edge|node)+\s+\[')
-        dot_format_value_regex = re.compile(r'^\s+[a-zA-Z]+\s+=\s[a-zA-Z]+\,+|^\s+];$')
-        dot_node_format_regex = re.compile(r'\s+"([^"]+)"\s+\[\s+label=\<')
-        dot_node_format_body_regex = re.compile(r'\s+(<[a-zA-Z0-9=\=\s\\ / \-"]+>|[a-zA-Z0-9\s\.])+')
+        dot_regex = re.compile(r'\s+"[^"]+" -> {(\s*"[^"]+")*}$')
+        dot_format_section_regex = re.compile(r'\s+(graph|edge|node)+\s+\[$')
+        dot_format_section_value_regex = re.compile(r'\s+[a-zA-Z]+\s*=\s*[a-zA-Z"0-9.]+\,*|^\s+];$')
+        dot_node_format_regex = \
+            re.compile(r'\s+"([^"]+)"\s+\[\s*(\s*[a-zA-Z]+\s*=\s*[a-zA-Z"0-9.]+\,*)*\s*label=<$')
+        dot_node_format_body_regex =\
+            re.compile(r'\s+(<[a-zA-Z0-9=\s\\\/\-"]+>|[a-zA-Z0-9\s\./]|>];)+$')
 
         self.client.run("info . --graph", assert_error=True)
 

--- a/conans/test/functional/command/info_test.py
+++ b/conans/test/functional/command/info_test.py
@@ -151,7 +151,7 @@ class InfoTest(unittest.TestCase):
             parent_reference = node_matches[0]
             deps_ref = [ConanFileReference.loads(references) for references in node_matches[1:]]
 
-            if parent_reference == "Hello0/0.1":
+            if parent_reference == "conanfile.py (Hello0/0.1)":
                 parent_ref = ConanFileReference("Hello0", None, None, None, validate=False)
             else:
                 parent_ref = ConanFileReference.loads(parent_reference)


### PR DESCRIPTION
Changelog: (Feature): Adds more features & functionality over the improved Conan dot graph from feature/6814

Adds colored nodes to distinguish: `root` conanfile (in green) from its dependencies:
- normal dependencies aka `requires()` in blue and
- build dependencies aka `build_requires()` in green.

The sample recipe was reduced a bit and a new `build_requires()` was added to illustrate the difference in color.

```python
from conans import ConanFile, CMake

class MyPkg(ConanFile):
    name = "mypkg"
    version = "1.2.3-rc1"

    def requirements(self):
        self.requires("openexr/2.4.0")
        self.requires("libjpeg/9d")
        self.requires("nasm/2.14")
        self.requires("openssl/1.1.1f")
        self.requires("libtiff/4.1.0")
        self.requires("cimg/2.8.3")
        self.requires("zstd/1.4.3")
        self.requires("opencv/4.1.1@conan/stable")
        self.requires("protobuf/3.9.1", override=True)
        
    def build_requirements(self):
        self.build_requires("tinyxml2/7.1.0")
        self.build_requires("gtest/1.8.1", force_host_context=True)
```
Note: context dependencies are yet not painted sepparately.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
